### PR TITLE
Unix sockets

### DIFF
--- a/.ci/scripts/complement.sh
+++ b/.ci/scripts/complement.sh
@@ -206,6 +206,11 @@ if [[ -n "$WORKERS" ]]; then
   # Workers can only use Postgres as a database.
   export PASS_SYNAPSE_COMPLEMENT_DATABASE=postgres
 
+  # We are using workers, so set up replication unix sockets if appropriate
+  if [[ -n "$UNIX_SOCKETS" ]]; then
+    export PASS_SYNAPSE_HTTP_REPLICATION_UNIX_SOCKETS=1
+  fi
+
   # And provide some more configuration to complement.
 
   # It can take quite a while to spin up a worker-mode Synapse for the first
@@ -223,6 +228,10 @@ else
   # The tests for importing historical messages (MSC2716)
   # only pass with monoliths, currently.
   test_tags="$test_tags,msc2716"
+fi
+
+if [[ -n "$UNIX_SOCKETS" ]]; then
+  export PASS_SYNAPSE_PUBLIC_UNIX_SOCKETS=1
 fi
 
 if [[ -n "$ASYNCIO_REACTOR" ]]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,23 @@ jobs:
 
           - arrangement: monolith
             database: SQLite
+            unix_sockets: True
+
+          - arrangement: monolith
+            database: Postgres
+            unix_sockets: True
+
+          - arrangement: workers
+            database: Postgres
+            unix_sockets: True
+
+          - arrangement: workers
+            database: Postgres
+            worker_types: 'event_persister:2, stream_writers=account_data+presence+receipts+to_device+typing, singles=background_worker+user_dir+frontend_proxy+media_repository+appservice, senders=pusher+federation_sender, readers=federation_reader+client_reader+synchrotron+federation_inbound+event_creator:2'
+            unix_sockets: True
+
+          - arrangement: monolith
+            database: SQLite
             reactor: asyncio
 
           - arrangement: monolith
@@ -56,6 +73,27 @@ jobs:
             database: Postgres
             reactor: asyncio
             worker_types: 'event_persister:2, stream_writers=account_data+presence+receipts+to_device+typing, singles=background_worker+user_dir+frontend_proxy+media_repository+appservice, senders=pusher+federation_sender, readers=federation_reader+client_reader+synchrotron+federation_inbound+event_creator:2'
+
+          - arrangement: monolith
+            database: SQLite
+            reactor: asyncio
+            unix_sockets: True
+
+          - arrangement: monolith
+            database: Postgres
+            reactor: asyncio
+            unix_sockets: True
+
+          - arrangement: workers
+            database: Postgres
+            reactor: asyncio
+            unix_sockets: True
+
+          - arrangement: workers
+            database: Postgres
+            reactor: asyncio
+            worker_types: 'event_persister:2, stream_writers=account_data+presence+receipts+to_device+typing, singles=background_worker+user_dir+frontend_proxy+media_repository+appservice, senders=pusher+federation_sender, readers=federation_reader+client_reader+synchrotron+federation_inbound+event_creator:2'
+            unix_sockets: True
 
 
     steps:
@@ -84,6 +122,7 @@ jobs:
           WORKER_TYPES: ${{ matrix.worker_types || '' }}
           # Take advantage of the fact that the validation for truthy doesn't actually exist here.
           ASYNCIO_REACTOR: ${{ matrix.reactor || '' }}
+          UNIX_SOCKETS: ${{ (matrix.unix_sockets) && 1 || '' }}
         run: |
           set -o pipefail
           COMPLEMENT_DIR=`pwd`/complement synapse-workers/.ci/scripts/complement.sh -json 2>&1 | synapse-workers/.ci/scripts/gotestfmt

--- a/README.md
+++ b/README.md
@@ -127,3 +127,20 @@ Grafana dashboards are provided in the contrib directory of the source repo.<br>
  but not the homeserver configuration are COTURN_MIN_PORT and COTURN_MAX_PORT, which default 
  if not set to 49153 and 49173, respectively. And you can enable COTURN_METRICS so you can see
  those pretty(boring) graphs.
+* *NGINX_LISTEN_UNIX_SOCKET*: Set to a path and file that is represented internally for
+   a Unix socket connection into the main entrypoint of the internal reverse proxy. If
+   you do not bind mount this location to outside the container, this is useless. For
+   example, set this to `/tmp/synapse-main.sock` and bind mount this to somewhere your
+   external reverse proxy can find it, such as `/dev/shm` or `/run`.
+* **Special Note for these next two options**: if you use either of these, they will create
+  sockets on the internal directory structure at `/run`. I highly recommend adding to
+  the docker start arguments `--tmpfs /run` so this will become non-persisted in the
+  docker layer. In unRAID, you can find this under `Advanced view` and `Extra
+  Parameters`. If you run into errors that sound like "Could not create socket file" or
+  "Could not create lock file" you may have forgotten to do this.(May fix this later, to
+  make sockets created onto `/dev/shm` instead as that is not persisted or exposed)
+  * *SYNAPSE_PUBLIC_UNIX_SOCKETS*: Set to anything(1 is fine) to enable internal usage of
+    Unix sockets between the internal reverse proxy and Synapse public facing endpoints.
+  * *SYNAPSE_HTTP_REPLICATION_UNIX_SOCKETS*: set to anything(1 is fine) to enable internal
+    Synapse HTTP replication endpoints to use Unix sockets. This only is useful if you
+    have any workers declared(see *SYNAPSE_WORKER_TYPES* above).

--- a/conf-workers/nginx.conf.j2
+++ b/conf-workers/nginx.conf.j2
@@ -6,8 +6,11 @@ log_format backend '[$time_local] - $proxy_add_x_forwarded_for - URT:$upstream_r
 
 upstream main_synapse_process {
     zone upstreams 64K;
+{% if enable_proxy_to_unix_socket %}
+    server unix:/run/main_public.sock;
+{% else %}
     server localhost:{{ main_proxy_pass_cli_port }};
-
+{% endif %}
     keepalive 2;
 }
 

--- a/conf-workers/nginx.conf.j2
+++ b/conf-workers/nginx.conf.j2
@@ -5,7 +5,7 @@
 log_format backend '[$time_local] - $proxy_add_x_forwarded_for - URT:$upstream_response_time request_time $request_time $status $upstream_addr: $request';
 
 upstream main_synapse_process {
-    zone upstreams 64K;
+    zone upstreams 512K;
 {% if enable_proxy_to_unix_socket %}
     server unix:/run/main_public.sock;
 {% else %}
@@ -22,7 +22,9 @@ server {
     # have to change any ports set up in your docker image
     listen {{ original_client_listener_port or '8008' }};
     listen [::]:{{ original_client_listener_port or '8008' }};
-
+{%- if main_entry_point_unix_socket is not none %}
+    listen unix:{{ main_entry_point_unix_socket }};
+{% endif -%}
 {% if tls_cert_path is not none and tls_key_path is not none %}
     # this allows for:
     # 1. Piping in a federation port directly if you have TlS certs in place. This is

--- a/conf-workers/nginx.conf.j2
+++ b/conf-workers/nginx.conf.j2
@@ -5,6 +5,12 @@
 log_format backend '[$time_local] - $proxy_add_x_forwarded_for - URT:$upstream_response_time request_time $request_time $status $upstream_addr: $request';
 
 upstream main_synapse_process {
+    # Several theoretical optimizations are in this block(and subsequently in the
+    # procedurally generated ones as well).
+    # zone *shared_memory_zone_name* *size*
+    # https://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone
+    # keepalive *number*
+    # https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
     zone upstreams 512K;
 {% if enable_proxy_to_unix_socket %}
     server unix:/run/main_public.sock;
@@ -54,12 +60,13 @@ server {
 
     # Nginx by default only allows file uploads up to 1M in size
     # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
-    client_max_body_size 100M;
+    client_max_body_size 0;
 
     # Synapse chunks responses according to the docs. We also want to use the keepalive
     # feature, so we need both of these globally.
     proxy_http_version 1.1;
     proxy_set_header "Connection" "";
+    proxy_socket_keepalive on;
 
 {{ worker_locations }}
 

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -1486,9 +1486,9 @@ def generate_worker_files(
         # Add 'main' to the instance_map if using workers
         instance_map = shared_config.setdefault("instance_map", {})
         instance_map["main"] = {
-                "host": "localhost",
-                "port": MAIN_PROCESS_NEW_REPLICATION_PORT,
-            }
+            "host": "localhost",
+            "port": MAIN_PROCESS_NEW_REPLICATION_PORT,
+        }
         # Redis wasn't found in the original config
         if not original_redis:
             # This is sufficient, because an existing statement of redis will be used.
@@ -1532,7 +1532,9 @@ def generate_worker_files(
             "/conf/prometheus.yml.j2",
             "/etc/prometheus/prometheus.yml",
             metric_endpoint_locations=prom_endpoint_config,
-            metric_scrape_interval=os.environ.get("SYNAPSE_METRICS_SCRAPE_INTERVAL", "15s")
+            metric_scrape_interval=os.environ.get(
+                "SYNAPSE_METRICS_SCRAPE_INTERVAL", "15s"
+            ),
         )
 
     # Supervisord config

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -321,6 +321,7 @@ NGINX_LOCATION_CONFIG_BLOCK = """
     }}
 """
 
+# Bump zone shared memory upto 512k from 64k
 NGINX_UPSTREAM_CONFIG_BLOCK = """
 upstream {upstream_name} {{
     zone upstreams 512K;

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -1175,7 +1175,9 @@ def generate_worker_files(
                 }
             ]
 
-        # Construct a separate health endpoint.
+        # Construct a separate health endpoint. If we are using unix sockets for other
+        # listeners seems prudent to use that here too. Since it is all self-contained
+        # in this image, it should be safe.
         if enable_replication_unix_sockets or enable_public_unix_sockets:
             new_health_listener = [
                 {

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -1005,6 +1005,10 @@ def generate_worker_files(
     enable_manhole_master = getenv_bool("SYNAPSE_MANHOLE_MASTER", False)
     enable_manhole_workers = getenv_bool("SYNAPSE_MANHOLE_WORKERS", False)
     enable_metrics = getenv_bool("SYNAPSE_METRICS", False)
+    enable_replication_unix_sockets = getenv_bool(
+        "SYNAPSE_HTTP_REPLICATION_UNIX_SOCKETS", False
+    )
+    enable_external_unix_sockets = getenv_bool("SYNAPSE_EXTERNAL_UNIX_SOCKETS", False)
     enable_internal_redis = False
 
     # First read the original config file and extract the listeners block and a few


### PR DESCRIPTION
Finally got around to adding in Unix Socket support for the image.

The internal Nginx reverse proxy can now listen for the external traffic on a Unix socket. Place a path into `NGINX_LISTEN_UNIX_SOCKET` *or* place a `path` based listener into your existing homeserver.yaml and it should make a socket file in that location internal to the docker image. You will need to have that socket exported with a bind mount to your external filesystem. 
Notes:
* For the moment, the internal Nginx will continue to listen on the port extracted from your existing homeserver.yaml or the default of `8008` as a backup measure. If you do not expose this outside the container, it will do nothing.
* All internal Unix sockets will be created on `/run`. A standard docker container will persist these files into the docker image layers. I *highly* recommend adding `--tmpfs /run` into your docker container start arguments, thus creating a non-persistent directory. There are some issues around locking I'll be looking into for upstream.

As an example for setting up `NGINX_LISTEN_UNIX_SOCKET`:
I have a directory that I bind mount into my container at `/dev/shm/sockets` and it shows up in my container under `/tmp/sockets`. I make an environment variable of `NGINX_LISTEN_UNIX_SOCKET=/tmp/sockets/synapse-main.sock` for my container. My external reverse proxy I point at `/dev/shm/sockets/synapse-main.sock`, and I'm ready to go.

`SYNAPSE_HTTP_REPLICATION_UNIX_SOCKETS` can be set to a 'truthy' value, such as `1` or `true` or anything really, and *only HTTP replication endpoints* will be setup to interconnect with Unix sockets automatically.

`SYNAPSE_PUBLIC_UNIX_SOCKETS` can be set to any value, and *only public facing endpoints* will be set up to use Unix sockets with the internal Nginx.

Special note: If either or both of these options is used together, `/health` will also be served on a Unix socket.

Updates:
* [x] <del>Media isn't loading</del>Fixed `media` listener resource types
* [x] Allow existing Unix socket `client` listeners in homeserver.yaml to be used as the main entry point for the internal Nginx listening socket. Existing host/port style `client` listeners already do this.
* [ ] If Synapse crashes, with an exception or other reason, the Nginx generated listener Unix socket is not automatically cleaned up. I don't know if there is anything I can do about this, but be aware. If you have restarted the container and it is trying to create the socket, you can remove it from where it is exposed with your bind mount and it should be able to proceed.