### PR TITLE
Prometheus Enhancements

### DIFF
--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -128,6 +128,8 @@ RUN rm /etc/nginx/sites-enabled/default
 # Copy over Prometheus. Should we bring the website files. It's 10's of MB's
 COPY --from=deps_base /usr/bin/prometheus /usr/bin
 COPY --from=deps_base /usr/share/prometheus/* /usr/share/prometheus
+# And Synapse's Prometheus rule file
+COPY /contrib/prometheus/synapse-V2.rules /etc/prometheus
 
 COPY --from=tools /out /
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ A few things make this container great:
  dynamically. As a worker that has no traffic directed at it is useless, this takes 
  care of the details. You will still need an external reverse proxy to handle the TLS 
  encryption(if you are using Unraid, swag is excellent at this).
-4. Support for metrics. If you like to look at pretty graphs in Grafana, this is 
- prometheus ready.
+4. Support for metrics. If you like to look at pretty graphs in Grafana, this has
+ Prometheus built-in(must be enabled, see below).
 ## Setup
 ### Pre-existing configuration
 Moving an existing instance of your homeserver from the normal docker image to this one
@@ -68,7 +68,7 @@ allow for easier regeneration of main configuration.
   database. The only actually required Postgres variable with no defaults.
 * *SYNAPSE_WORKERS_WRITE_LOGS_TO_DISK*: 1 or 0
 * *SYNAPSE_LOG_LEVEL*: ERROR, WARNING, INFO, DEBUG. INFO is default
-* SYNAPSE_METRICS: 'yes', '1', 'true', or 'on'. Anything else is a 'no'
+* *SYNAPSE_METRICS*: 'yes', '1', 'true', or 'on'. Anything else is a 'no'
 
 Not required to set as the defaults are good. Only accessed on first generate of main config, ignored otherwise.
 * *SYNAPSE_CONFIG_DIR* and *SYNAPSE_DATA_DIR*: /data is the default. Both point to 
@@ -109,8 +109,12 @@ Paths to map to somewhere as volumes
 ### Additions
 Anything in this section can be enabled by giving it a value of  'yes', 'y', '1', 'true', 't', 
 or 'on'. Anything else is a 'no'
-* *SYNAPSE_METRICS*: This will enable the builtin prometheus service and add the necessary bits 
- to Synapse to expose metrics.
+* *SYNAPSE_METRICS*: This not only is part of the generation of the initial homeserver.yaml file,
+  but will also enable the builtin prometheus service and add the necessary bits
+  to Synapse to expose metrics.
+* *SYNAPSE_METRICS_UNIX_SOCKETS*: Enable Unix socket scraping support. **IMPORTANT NOTE**:
+  this does not currently work as Prometheus does not support scraping a Unix socket for
+  general scraping. See [issue](github.com/prometheus/prometheus/issues/12024) for details.
 * *SYNAPSE_ENABLE_REDIS_METRIC_EXPORT*: Redis is built into the docker image. It will 
  automatically be used whenever a worker or multiple workers are declared. This enables 
  exporting Redis metrics to the built-in Prometheus service. SYNAPSE_METRICS is required.
@@ -144,3 +148,6 @@ Grafana dashboards are provided in the contrib directory of the source repo.<br>
   * *SYNAPSE_HTTP_REPLICATION_UNIX_SOCKETS*: set to anything(1 is fine) to enable internal
     Synapse HTTP replication endpoints to use Unix sockets. This only is useful if you
     have any workers declared(see *SYNAPSE_WORKER_TYPES* above).
+* *PROMETHEUS_SCRAPE_INTERVAL*: Defaults to 15 seconds, allows the built-in Prometheus
+  scrape interval to be changed. This will be set to the global `scrape_interval` as well
+  as the one for the Synapse job.

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -29,6 +29,6 @@ scrape_configs:
     - targets: ["localhost:8060"]
       labels:
         instance: "Synapse"
-        job: "Main Homeserver"
+        job: "main_process"
         index: 1
 {{ metric_endpoint_locations }}

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -26,7 +26,7 @@ scrape_configs:
     scrape_interval: {{ metric_scrape_interval }}
     metrics_path: "/_synapse/metrics"
     static_configs:
-    - targets: ["localhost:8060"]
+    - targets: ["{{ main_process_target}}"]
       labels:
         instance: "Synapse"
         job: "main_process"

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -307,6 +307,7 @@ HTTP_BASED_LISTENER_RESOURCES = [
     "client",
     "federation",
     "media",
+    "metrics",
     "replication",
 ]
 
@@ -1289,8 +1290,8 @@ def generate_worker_files(
             {
                 "port": MAIN_PROCESS_HTTP_METRICS_LISTENER_PORT,
                 "bind_address": "0.0.0.0",
-                "type": "metrics",
-                "resources": [{"compress": True}],
+                "type": "http",
+                "resources": [{"names": ["metrics"], "compress": True}],
             }
         ]
         listeners += metric_listener
@@ -1533,7 +1534,6 @@ def generate_worker_files(
         for listener in worker.listener_resources:
             this_listener: Dict[str, Any] = {}
             if listener in HTTP_BASED_LISTENER_RESOURCES:
-                binding_port_or_path = "port"
                 if enable_replication_unix_sockets and listener in ["replication"]:
                     this_listener = construct_worker_listener_block(
                         worker.listener_port_map[listener], [listener], True, False
@@ -1553,11 +1553,12 @@ def generate_worker_files(
                         worker.listener_port_map[listener], [listener], True, False
                     )
                 else:
+                    # This should only be for metrics, as manhole is its own type
                     this_listener = construct_worker_listener_block(
-                        worker.listener_port_map[listener], [listener], False, False
+                        worker.listener_port_map[listener], [listener], False, True
                     )
-            # The 'metrics' and 'manhole' listeners don't use 'http' as their type.
-            elif listener in ["metrics", "manhole"]:
+            # The 'manhole' listener doesn't use 'http' as its type.
+            elif listener in ["manhole"]:
                 this_listener = {
                     "type": listener,
                     "port": worker.listener_port_map[listener],

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -1759,9 +1759,7 @@ def generate_worker_files(
             "/conf/prometheus.yml.j2",
             "/etc/prometheus/prometheus.yml",
             metric_endpoint_locations=prom_endpoint_config,
-            metric_scrape_interval=os.environ.get(
-                "SYNAPSE_METRICS_SCRAPE_INTERVAL", "15s"
-            ),
+            metric_scrape_interval=os.environ.get("PROMETHEUS_SCRAPE_INTERVAL", "15s"),
         )
 
     # Supervisord config


### PR DESCRIPTION
* [x] Fix loading of Synapse's Prometheus rule file
* [x] Rename Synapse's main process to remove a space that is troublesome for PromQL queries(needed to edit each graph from the contributed Grafana JSON to change `instance="$instance"` to `instance=~"$instance"`)
* [x] Rename `SYNAPSE_METRIC_SCRAPE_INTERVAL` to `PROMETHEUS_SCRAPE_INTERVAL`, as it doesn't change any Synapse configuration, only Prometheus.
* [x] Allow worker metric endpoints to be an 'http' type, thus allowing compression for the connection, and allowing for future usage of Unix sockets.
* [x] Allow Unix sockets for metrics scraping from Synapse. Full disclosure: [*This does not work because Prometheus does not support scraping from a Unix Socket yet*](https://github.com/prometheus/prometheus/issues/12024).
* [ ] <del>Add in `basic_auth_users` capability</del> Update: The website that this authenticates against/for is not part of the image.
* [x] Update README
  * [x] Document `PROMETHEUS_SCRAPE_INTERVAL` which defaults to 15 seconds
  * [x] Document `SYNAPSE_METRICS_UNIX_SOCKETS` to enable Unix Sockets for metrics scraping, defaults off
