### PR TITLE
Update Nginx to latest stable version

### DIFF
--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -46,7 +46,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \
-      nginx-light \
       prometheus \
       && rm -rf /var/lib/apt/lists/*
 
@@ -59,6 +58,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #
 # We will be using the PPA version of keydb until their docker image works for bookworm
 # FROM eqalpha/keydb:latest AS redis_base
+
+# Do the same for the Nginx docker image.
+FROM nginx:1.24.0 as nginx_base
 
 # The synapse auto compressor is from an image we build. It won't change much
 # so there's no reason to not have this pre-compiled and just borrow it. This also
@@ -112,8 +114,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Prepare directories. Do it in one layer
 RUN mkdir -p /etc/supervisor/conf.d && \
-    mkdir /var/log/nginx /var/lib/nginx && \
-    chown www-data /var/log/nginx /var/lib/nginx && \
+    mkdir /var/log/nginx /var/cache/nginx && \
+    chown www-data /var/log/nginx /var/cache/nginx && \
     mkdir -p /etc/prometheus
 
 # Install supervisord with pip instead of apt, to avoid installing a second
@@ -124,11 +126,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Copy over redis and nginx
 # COPY --from=redis_base /usr/local/bin/keydb-server /usr/local/bin
 
-COPY --from=deps_base /usr/sbin/nginx /usr/sbin
-COPY --from=deps_base /usr/share/nginx /usr/share/nginx
-COPY --from=deps_base /usr/lib/nginx /usr/lib/nginx
-COPY --from=deps_base /etc/nginx /etc/nginx
-RUN rm /etc/nginx/sites-enabled/default
+COPY --from=nginx_base /usr/sbin/nginx /usr/sbin
+COPY --from=nginx_base /usr/share/nginx /usr/share/nginx
+COPY --from=nginx_base /usr/lib/nginx /usr/lib/nginx
+COPY --from=nginx_base /etc/nginx /etc/nginx
+RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy over Prometheus. Should we bring the website files. It's 10's of MB's
 COPY --from=deps_base /usr/bin/prometheus /usr/bin

--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -93,6 +93,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libpq5 \
       libssl-dev \
       libwebp7 \
+      logrotate \
       nano \
       openssl \
       prometheus-nginx-exporter \

--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -129,6 +129,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 COPY --from=nginx_base /usr/sbin/nginx /usr/sbin
 COPY --from=nginx_base /usr/share/nginx /usr/share/nginx
 COPY --from=nginx_base /usr/lib/nginx /usr/lib/nginx
+COPY --from=nginx_base /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=nginx_base /etc/nginx /etc/nginx
 RUN rm /etc/nginx/conf.d/default.conf
 

--- a/README.md
+++ b/README.md
@@ -244,3 +244,8 @@ another to connect to the upstream. So, the formula is:
   do it anyways. I suppose the request/response has to be placed somewhere before
   transferring on it's way. It speaks of it being synchronous in nature, which implies
   that when enabled it is asynchronous.
+* Part of the metrics acquisition process requires creating a special log file to scrape
+  for the data. This log file is internal to the container and is not exposed by default.
+  `logrotate` is used to keep the file to a more manageable level. Disable `logrotate`
+  by setting `NGINX_DISABLE_LOGROTATE` to a 'truthy' value and then you can manage this 
+  log file yourself.

--- a/conf-workers/nginx.logrotate
+++ b/conf-workers/nginx.logrotate
@@ -1,0 +1,9 @@
+/var/log/nginx/mtail.log {
+    daily
+    rotate 1
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    missingok
+}

--- a/conf-workers/run_compressor.sh.j2
+++ b/conf-workers/run_compressor.sh.j2
@@ -1,2 +1,2 @@
 #!/bin/sh
-synapse_auto_compressor -p postgresql://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_host }}:{{ postgres_port }}/{{ postgres_db }} -c 500 -n 100
+synapse_auto_compressor -p 'postgresql://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_db }}?host={{ postgres_host }}{{ "&port=" + postgres_port if postgres_port }}' -c 500 -n 100

--- a/conf-workers/supervisord.conf.j2
+++ b/conf-workers/supervisord.conf.j2
@@ -65,7 +65,7 @@ autorestart=unexpected
 autostart={{ enable_prometheus }}
 
 [program:nginx_log_exporter]
-command=/usr/local/bin/prefix-log /usr/local/bin/mtail -logtostderr -port 9112 -progs /conf/mtail -logs /var/log/nginx/access.log
+command=/usr/local/bin/prefix-log /usr/local/bin/mtail -logtostderr -port 9112 -progs /conf/mtail -logs /var/log/nginx/mtail.log
 priority=500
 stdout_logfile=/var/log/mtail_stdout.log
 stdout_logfile_maxbytes=0

--- a/conf-workers/supervisord.conf.j2
+++ b/conf-workers/supervisord.conf.j2
@@ -90,12 +90,12 @@ exitcodes=0
 [program:cron]
 priority = 500
 command = /usr/local/bin/prefix-log /usr/sbin/cron -f -L 15
-autorestart = unexpected
-autostart={{ enable_compressor }}
-stdout_logfile =/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+autorestart = true
+autostart = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:coturn]
 priority = 500

--- a/conf-workers/synapse-nginx.conf.j2
+++ b/conf-workers/synapse-nginx.conf.j2
@@ -76,8 +76,11 @@ server {
 
     server_name localhost;
 
-    access_log /var/log/nginx/synapse.log backend;
-    access_log /var/log/nginx/access.log mtail;
+    # access.log is the human readable log
+    access_log /var/log/nginx/access.log backend;
+    # mtail.log is the metrics log that will be parsed by mtail. logrotate will take
+    # care of making sure this doesn't get to large, as it lives in the container.
+    access_log /var/log/nginx/mtail.log mtail;
     error_log /var/log/nginx/error.log warn;
 
 {{ worker_locations }}

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -2003,6 +2003,7 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
         getenv_bool("SYNAPSE_ENABLE_POSTGRES_METRIC_EXPORT", False)
         and "POSTGRES_PASSWORD" in environ
     )
+    disable_nginx_logrotate = getenv_bool("NGINX_DISABLE_LOGROTATE", False)
 
     # override SYNAPSE_NO_TLS, we don't support TLS in worker mode,
     # this needs to be handled by a frontend proxy
@@ -2085,6 +2086,18 @@ def main(args: List[str], environ: MutableMapping[str, str]) -> None:
                 stdout=subprocess.PIPE,
             ).stdout.decode("utf-8")
 
+        if not disable_nginx_logrotate:
+            # This is the default. Add the file into the logrotate directory
+            subprocess.run(
+                ["cp", "/conf/nginx.logrotate", "/etc/logrotate.d"],
+                stdout=subprocess.PIPE,
+            ).stdout.decode("utf-8")
+
+        else:
+            subprocess.run(
+                ["rm", "/etc/logrotate.d/nginx.logrotate"],
+                stdout=subprocess.PIPE,
+            )
         # Make postgres_exporter custom script if enabled in environment.
         if enable_postgres_exporter is True:
             convert(


### PR DESCRIPTION
...and adjust settings to bring them up-to-date.

Tried `extrepo` to install as a debian pkg, it was almost 50MB heavier.

Found [nginx@docker](https://hub.docker.com/_/nginx) and they have a bullseye version of Nginx prebuilt and ready. This was only 4MB more than the 'light' version of Nginx we were using and includes a bunch of modules we will probably never use(like geoip). 4MB is acceptable.

Add in logrotate as well(by request but also because it's a good idea)

The log file used to scrape for metrics can grow inside the docker image until it is quite large. It would only be removed when the container is remade. This will help control the size, since this file is otherwise not used. logrotate will only touch the metrics scraping tool logs and rotate it once a day. This behavior can be disabled(allowing your own method of log containment) by setting `NGINX_DISABLE_LOGROTATE` to a 'truthy' value. Access to the logrotate configuration is by traditional bind-mounting of the `/etc/logrotate.d` directory. Inside is a file(that will be removed if the above environment variable is set) that controls this behavior. If you wish to customize it, copy it first to a new file name and then set the environment variable to disable the default function and it will run as expected. logrotate will always run now(as will cron). 
*NOTE*: I was not able to get logging of cron jobs enabled for this PR.

Previously, the log files Nginx created were defined as:
```log
/var/log/nginx/synapse.log   -> access logging
/var/log/nginx/access.log    -> metrics scraping
/var/log/nginx/error.log     -> error logging
```
This will be changing to:
```log
/var/log/nginx/access.log    -> access logging
/var/log/nginx/mtail.log     -> metrics scraping
/var/log/nginx/error.log     -> error logging
```
to better match intended and intuitive naming conventions.