### PR TITLE
Update logrotate Logic for nginx.

### DIFF
--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -132,6 +132,7 @@ COPY --from=nginx_base /usr/share/nginx /usr/share/nginx
 COPY --from=nginx_base /usr/lib/nginx /usr/lib/nginx
 COPY --from=nginx_base /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=nginx_base /etc/nginx /etc/nginx
+COPY --from=nginx_base /etc/init.d/nginx /etc/init.d/nginx
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy over Prometheus. Should we bring the website files. It's 10's of MB's

--- a/conf-workers/nginx.logrotate
+++ b/conf-workers/nginx.logrotate
@@ -1,19 +1,18 @@
-/var/log/nginx/mtail.log {
-    daily
-    rotate 1
-    copytruncate
-    compress
-    delaycompress
-    notifempty
-    missingok
-}
-
-/var/log/nginx/access.log {
-    daily
-    rotate 7
-    copytruncate
-    compress
-    delaycompress
-    notifempty
-    missingok
+/var/log/nginx/*.log {
+	daily
+	missingok
+	rotate 7
+	compress
+	delaycompress
+	notifempty
+	create 0640 root root
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
 }


### PR DESCRIPTION
I seemed to notice that the logrotate is not working properly. After delving a little bit deeper it seems related to how you install the pkgs.

As I understand you pull the nginx image and copy the data from there. The normal way to install packages is via PKG manager. If you install nginx via apt, then it would automagically add all the config for logrotate.

It seems the issue is that the log file is not rotated for the nginx service. The APT repo script has a 'postrotate' logic that invokes a script in `/etc/init.d` folder. I also added a Docker build option to copy over that script from the nginx image.

I updated the logrotate file itself to use logic similar to the APT repo.

The file from APT is the following:
```
/var/log/nginx/*.log {
	daily
	missingok
	rotate 14
	compress
	delaycompress
	notifempty
	create 0640 www-data adm
	sharedscripts
	prerotate
		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
			run-parts /etc/logrotate.d/httpd-prerotate; \
		fi \
	endscript
	postrotate
		invoke-rc.d nginx rotate >/dev/null 2>&1
	endscript
}
```
1. I also changed the file permissions to root/root.
2. I changed the rotate to keep 7 days of content in total.

I have built the image and tested logrotate inside the container. Let's hope it works now :-)