### PR TITLE
Rotate NGINX logs daily.

### DIFF
--- a/conf-workers/nginx.logrotate
+++ b/conf-workers/nginx.logrotate
@@ -1,6 +1,6 @@
 /var/log/nginx/mtail.log {
     daily
-    rotate 1
+    rotate 0
     copytruncate
     compress
     delaycompress
@@ -10,7 +10,7 @@
 
 /var/log/nginx/access.log {
     daily
-    rotate 7
+    rotate 0
     copytruncate
     compress
     delaycompress


### PR DESCRIPTION
As the metrics and whatnot are collected from the files, they are not relevant for storing. 

The logfiles are getting rather big and as the logs are collected by prometheus there is not point in keeping even 'yesterdays' logs.