### PR TITLE
Fix-ups listener resource creation

### DIFF
--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -355,9 +355,11 @@ class Worker:
         listener_resources: Set of types of listeners needed. 'client, federation,
             replication, media' etc.
         listener_port_map: Dict of 'listener':port_number so 'client':18900
+        main_port: The main port number for most primary listeners('client', 'federation', etc)
         health_port: The port number for the /health endpoint
         manhole_port: The port number for ssh-ing into a running synapse. Will not be a Unix socket
         metrics_port: The port number for the metrics endpoints
+        replication_port: The port number for replication, if needed
         endpoint_patterns: Dict of listener resource containing url endpoints this
             worker accepts connections on. Because a worker can merge multiple roles
             with potentially different listeners, this is important. e.g.
@@ -375,9 +377,11 @@ class Worker:
     app: str
     listener_resources: Set[str]
     listener_port_map: Dict[str, int]
+    main_port: int
     health_port: int
     manhole_port: int
     metrics_port: int
+    replication_port: int
     endpoint_patterns: Dict[str, Set[str]]
     shared_extra_config: Dict[str, Any]
     worker_extra_conf: str
@@ -408,9 +412,11 @@ class Worker:
         self.endpoint_patterns = defaultdict(set[str])
         self.shared_extra_config = {}
         self.listener_port_map = defaultdict(int)
+        self.main_port = 0
         self.health_port = 0
         self.manhole_port = 0
         self.metrics_port = 0
+        self.replication_port = 0
         self.types_list = []
         self.worker_extra_conf = ""
         self.base_name = ""

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -1510,6 +1510,7 @@ def generate_worker_files(
         log_config_filepath = generate_worker_log_config(environ, worker.name, data_dir)
 
         # Build the worker_listener block for the worker.yaml
+        # TODO: worker_listeners should be a List, not a JsonDict. Fix
         worker_listeners: Dict[str, Any] = {}
         if worker.listener_resources:
             this_listener = construct_worker_listener_block(

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -111,7 +111,7 @@ WORKERS_CONFIG: Dict[str, Dict[str, Any]] = {
     },
     "media_repository": {
         "app": "synapse.app.generic_worker",
-        "listener_resources": ["media"],
+        "listener_resources": ["client", "federation", "media"],
         "endpoint_patterns": [
             "^/_matrix/media/",
             "^/_synapse/admin/v1/purge_media_cache$",

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -647,9 +647,19 @@ class Workers:
         """
         self.worker[worker_name].listener_port_map[
             resource_name
-        ] = self.current_port_counter
-        # Increment the counter
+        ] = self.get_next_port_number()
+
+    def get_next_port_number(self) -> int:
+        """
+        Increment and return the port number counter. This will initially create a gap
+        at the beginning at the sequence as one number gets skipped over. Ignore it as
+        annoying but not world-breaking
+
+        Returns: int of the next port number to assign
+
+        """
         self.current_port_counter += 1
+        return self.current_port_counter
 
 
 class NginxConfig:

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -758,25 +758,18 @@ class NginxConfig:
         # Add nginx location blocks for this worker's endpoints (if any are defined)
         # Inappropriate types of listeners were already filtered out.
         for worker in workers.worker.values():
-            for listener_type, patterns in worker.endpoint_patterns.items():
-                for pattern in patterns:
-                    # Collect port numbers for this endpoint pattern
-                    locations_to_port_set.setdefault(pattern, set()).add(
-                        worker.listener_port_map[listener_type]
-                    )
-                # Set lookup maps to be used for combining upstreams in a moment.
-                # Need the worker's base name
-                port_to_upstream_name.setdefault(
-                    worker.listener_port_map[listener_type], worker.base_name
-                )
-                # The listener type
-                port_to_listener_type.setdefault(
-                    worker.listener_port_map[listener_type], listener_type
-                )
-                # And the list of roles this(possibly combination) worker can fill
-                self.upstreams_roles.setdefault(worker.base_name, set()).update(
-                    worker.types_list
-                )
+            for pattern in worker.endpoint_patterns:
+                # Collect port numbers for this endpoint pattern
+                locations_to_port_set.setdefault(pattern, set()).add(worker.main_port)
+
+            # Set lookup maps to be used for combining upstreams in a moment.
+            # Need the worker's base name
+            port_to_upstream_name.setdefault(worker.main_port, worker.base_name)
+
+            # And the list of roles this(possibly combination) worker can fill
+            self.upstreams_roles.setdefault(worker.base_name, set()).update(
+                worker.types_list
+            )
 
         for endpoint_pattern, port_set in locations_to_port_set.items():
             # Reset these for each run

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -759,9 +759,6 @@ class NginxConfig:
 
             # This will be the name of the upstream
             new_nginx_upstream = f"{'-'.join(sorted(new_nginx_upstream_set))}"
-            new_nginx_upstream += (
-                f".{'-'.join(sorted(new_nginx_upstream_listener_set))}"
-            )
 
             # Check this upstream exists, if not then make it
             if new_nginx_upstream not in self.upstreams_to_ports:

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -354,7 +354,6 @@ class Worker:
         app: 'synapse.app.generic_worker' for all now
         listener_resources: Set of types of listeners needed. 'client, federation,
             replication, media' etc.
-        listener_port_map: Dict of 'listener':port_number so 'client':18900
         main_port: The main port number for most primary listeners('client', 'federation', etc)
         health_port: The port number for the /health endpoint
         manhole_port: The port number for ssh-ing into a running synapse. Will not be a Unix socket
@@ -373,7 +372,6 @@ class Worker:
     index: int
     app: str
     listener_resources: Set[str]
-    listener_port_map: Dict[str, int]
     main_port: int
     health_port: int
     manhole_port: int
@@ -408,7 +406,6 @@ class Worker:
         self.listener_resources = set()
         self.endpoint_patterns = set()
         self.shared_extra_config = {}
-        self.listener_port_map = defaultdict(int)
         self.main_port = 0
         self.health_port = 0
         self.manhole_port = 0

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -438,7 +438,7 @@ class Worker:
             self.app = str(worker_config.get("app"))
 
             # Get the listener_resources
-            listener_resources = worker_config.get("listener_resources")
+            listener_resources = worker_config.get("listener_resources", [])
             if listener_resources:
                 self.listener_resources.update(listener_resources)
 


### PR DESCRIPTION
Due to recent developments in upstream, multiple types of listeners(`client`, `federation`, and `media` primarily) are now expected to be declarable on any given worker. While this may or may not continue to be true in the future, it is a good opportunity to overhaul how listener resources are declared for this image. To be clear, this was always allowed in Synapse's configuration it just didn't *usually* happen in this image.

Currently, all types of listener resources are given their own port/path. 
* In the case of `health`, this was thought to be a performance improvement(in responsiveness IIRC).
* In the case of `replication` it allowed for Unix sockets to be used where other resource types could be TCP, and vice versa. 
* In the case of `metrics`, it allowed for using TCP when everything else could be Unix sockets(as Prometheus doesn't support scraping a Unix socket at this time).

There was also a possibility that a future version of Twisted that would be multiprocessing-enabled would allow separated threading per listener, thereby giving a free performance improvement. No confirmation on this in any case.

Moving forward, allow combining the other main types of listener resources(again: `client`, `federation`, and `media`) onto a single port/path. The above specific use cases will be preserved.