### PR TITLE
Enhance metrics capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Grafana dashboards are provided in the contrib directory of the source repo.<br>
  exporting Redis metrics to the built-in Prometheus service. SYNAPSE_METRICS is required.
 * *SYNAPSE_ENABLE_POSTGRES_METRIC_EXPORT*: If you are using a Postgresql Database, it can grab
   metrics from it as well. SYNAPSE_METRICS is required.
+### Prometheus specifics
+* *PROMETHEUS_INSTANCE_NAME*: Defaults to "Synapse". Use this to customize what name you wish
+  for this instance to carry in Prometheus. A server name is appropriate here
 * *PROMETHEUS_REMOTE_WRITE_HTTP_URL*: No default. If set to an external timescale database,
   will add the correct `remote_write` block into the prometheus configuration. Use for things
   like [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)). See
@@ -159,10 +162,20 @@ Grafana dashboards are provided in the contrib directory of the source repo.<br>
   for more details about remote storage options. Using the default port and adjusting
   '<victoriametrics-addr>' for your own IP or hostname, this
   `http://<victoriametrics-addr>:8428/api/v1/write` should be enough to get started.
+
+See [Prometheus configuration docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration)
+for more information on the below options
+
+* *PROMETHEUS_REMOTE_WRITE_CAPACITY*: Defaults to 10000
+* *PROMETHEUS_REMOTE_WRITE_MAX_SAMPLES_PER_SEND*: Defaults to 2000
+* *PROMETHEUS_REMOTE_WRITE_MIN_SHARDS*: Defaults to 1
+* *PROMETHEUS_REMOTE_WRITE_MAX_SHARDS*: Defaults to 50
 * *PROMETHEUS_SCRAPE_INTERVAL*: Defaults to 15 seconds, allows the built-in Prometheus
   scrape interval to be changed. This will be set to the global `scrape_interval` as well
   as the one for the Synapse job.
-* *PROMETHEUS_STORAGE_RETENTION_TIME*: Defaults to `1y`. Time for prometheus to retain metrics data. (https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects)
+* *PROMETHEUS_STORAGE_RETENTION_TIME*: Defaults to `1y`. Time for prometheus to retain metrics data.
+  [More on this](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects). If you have
+  enabled remote write above, you can turn this down to some more reasonable.
 
 * **
 

--- a/README.md
+++ b/README.md
@@ -164,18 +164,35 @@ Grafana dashboards are provided in the contrib directory of the source repo.<br>
   `http://<victoriametrics-addr>:8428/api/v1/write` should be enough to get started.
 
 See [Prometheus configuration docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration)
-for more information on the below options
+for more information on the below options. The first 4 are potentially useful, the rest are provided
+just in case.
+
+<details>
+<summary>More Prometheus options
+</summary>
 
 * *PROMETHEUS_REMOTE_WRITE_CAPACITY*: Defaults to 10000
 * *PROMETHEUS_REMOTE_WRITE_MAX_SAMPLES_PER_SEND*: Defaults to 2000
 * *PROMETHEUS_REMOTE_WRITE_MIN_SHARDS*: Defaults to 1
 * *PROMETHEUS_REMOTE_WRITE_MAX_SHARDS*: Defaults to 50
+* *PROMETHEUS_REMOTE_WRITE_BATCH_SEND_DEADLINE*: Defaults to 5s
+* *PROMETHEUS_REMOTE_WRITE_MIN_BACKOFF*: Defaults to 30ms
+* *PROMETHEUS_REMOTE_WRITE_MAX_BACKOFF*: Defaults to 5s
+* *PROMETHEUS_REMOTE_WRITE_TIMEOUT*: Defaults to 30s
+* <del>*PROMETHEUS_REMOTE_WRITE_SEND_EXEMPLARS*: Defaults to False(may require support from remote TSDB)</del>
+* *PROMETHEUS_REMOTE_WRITE_SEND_NATIVE_HISTOGRAMS*: Defaults to False(may require support from remote TSDB)
+* <del>*PROMETHEUS_REMOTE_WRITE_ROUND_ROBIN_DNS*: Defaults to False. Only really useful if not using an IP address
+  for the remote TSDB.</del>
+* *PROMETHEUS_REMOTE_WRITE_RETRY_ON_HTTP_429*: Defaults to False
+* <del>*PROMETHEUS_REMOTE_WRITE_SAMPLE_AGE_LIMIT*: *Currently Disabled*. Defaults to 0s, which disables it</del>
 * *PROMETHEUS_SCRAPE_INTERVAL*: Defaults to 15 seconds, allows the built-in Prometheus
   scrape interval to be changed. This will be set to the global `scrape_interval` as well
   as the one for the Synapse job.
 * *PROMETHEUS_STORAGE_RETENTION_TIME*: Defaults to `1y`. Time for prometheus to retain metrics data.
   [More on this](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects). If you have
   enabled remote write above, you can turn this down to some more reasonable.
+
+</details>
 
 * **
 

--- a/README.md
+++ b/README.md
@@ -109,17 +109,6 @@ Paths to map to somewhere as volumes
 ### Additions
 Anything in this section can be enabled by giving it a value of  'yes', 'y', '1', 'true', 't',
 or 'on'. Anything else is a 'no'.
-* *SYNAPSE_METRICS*: This not only is part of the generation of the initial homeserver.yaml file,
-  but will also enable the builtin prometheus service, enable collection of Nginx metrics
-  and add the necessary bits to Synapse to expose metrics.
-* *SYNAPSE_METRICS_UNIX_SOCKETS*: Enable Unix socket scraping support. **IMPORTANT NOTE**:
-  this does not currently work as Prometheus does not support scraping a Unix socket for
-  general scraping. See [issue](github.com/prometheus/prometheus/issues/12024) for details.
-* *SYNAPSE_ENABLE_REDIS_METRIC_EXPORT*: Redis is built into the docker image. It will
- automatically be used whenever a worker or multiple workers are declared. This enables
- exporting Redis metrics to the built-in Prometheus service. SYNAPSE_METRICS is required.
-* *SYNAPSE_ENABLE_POSTGRES_METRIC_EXPORT*: If you are using a Postgresql Database, it can grab
-* metrics from it as well. SYNAPSE_METRICS is required.
 * *SYNAPSE_ENABLE_COMPRESSOR*: The Matrix team made a database compressor that can make the
  state parts of the database less....sprawly? It's included by default. Enable to run it as a
  cron job every sunday at 1am. Actual space saving will not occur until your next auto-vaccuum
@@ -148,10 +137,33 @@ Grafana dashboards are provided in the contrib directory of the source repo.<br>
   * *SYNAPSE_HTTP_REPLICATION_UNIX_SOCKETS*: set to anything(1 is fine) to enable internal
     Synapse HTTP replication endpoints to use Unix sockets. This only is useful if you
     have any workers declared(see *SYNAPSE_WORKER_TYPES* above).
+* **
+## Metrics
+* *SYNAPSE_METRICS*: This will enable the built-in prometheus service and set it up to scrape
+  the main process and any workers. If the below other variables are declared, they will be
+  incorporated into the scrape targets.
+* *SYNAPSE_METRICS_ENABLE_LISTENERS*: Defaults to *True* if *SYNAPSE_METRICS* is also *True*,
+  otherwise *False*. This can be used to force the metric endpoints in Synapse to be setup.
+* *SYNAPSE_METRICS_UNIX_SOCKETS*: Enable Unix socket scraping support. **IMPORTANT NOTE**:
+  this does not currently work as Prometheus does not support scraping a Unix socket for
+  general scraping. See [issue](github.com/prometheus/prometheus/issues/12024) for details.
+* *SYNAPSE_ENABLE_REDIS_METRIC_EXPORT*: Redis is built into the docker image. It will
+ automatically be used whenever a worker or multiple workers are declared. This enables
+ exporting Redis metrics to the built-in Prometheus service. SYNAPSE_METRICS is required.
+* *SYNAPSE_ENABLE_POSTGRES_METRIC_EXPORT*: If you are using a Postgresql Database, it can grab
+  metrics from it as well. SYNAPSE_METRICS is required.
+* *PROMETHEUS_REMOTE_WRITE_HTTP_URL*: No default. If set to an external timescale database,
+  will add the correct `remote_write` block into the prometheus configuration. Use for things
+  like [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)). See
+  [prometheus docs](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations)
+  for more details about remote storage options. Using the default port and adjusting
+  '<victoriametrics-addr>' for your own IP or hostname, this
+  `http://<victoriametrics-addr>:8428/api/v1/write` should be enough to get started.
 * *PROMETHEUS_SCRAPE_INTERVAL*: Defaults to 15 seconds, allows the built-in Prometheus
   scrape interval to be changed. This will be set to the global `scrape_interval` as well
   as the one for the Synapse job.
 * *PROMETHEUS_STORAGE_RETENTION_TIME*: Defaults to `1y`. Time for prometheus to retain metrics data. (https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects)
+
 * **
 
 ## Nginx configuration

--- a/conf-workers/homeserver.yaml
+++ b/conf-workers/homeserver.yaml
@@ -50,7 +50,7 @@ listeners:
 {% endif %}
       - names: [federation]
         compress: true
-{% if SYNAPSE_METRICS == "True" %}
+{% if SYNAPSE_METRICS_HTTP_PORT %}
   - port: {{ SYNAPSE_METRICS_HTTP_PORT or 8060}}
     bind_address: '0.0.0.0'
     type: metrics

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -40,4 +40,4 @@ scrape_configs:
     metrics_path: "/_synapse/metrics"
     file_sd_configs:
       - files:
-        - '/data/target.json'
+        - "{{ target_file_name }}"

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -5,39 +5,44 @@ global:
     monitor: 'monitor'
 rule_files:
   - "/etc/prometheus/synapse-V2.rules"
-{% if prom_remote_write_url %}
+{% if prom_config.rw_url_path %}
 remote_write:
-  - url: {{ prom_remote_write_url }}
+  - url: {{ prom_config.rw_url_path }}
+    queue_config:
+      max_samples_per_send: {{ prom_config.rw_max_samples_per_send}}
+      capacity: {{ prom_config.rw_capacity }}
+      min_shards: {{ prom_config.rw_min_shards }}
+      max_shards: {{ prom_config.rw_max_shards }}
 {% endif %}
 scrape_configs:
   - job_name: pg_exporter
     static_configs:
     - targets: ["localhost:9187"]
       labels:
-        instance: "Synapse Postgres"
+        instance: "{{ prom_config.instance_name }} Postgres"
   - job_name: redis_exporter
     static_configs:
     - targets: ["localhost:9121"]
       labels:
-        instance: "Synapse-Redis"
+        instance: "{{ prom_config.instance_name }}-Redis"
   - job_name: coturn_exporter
     static_configs:
     - targets: ["localhost:9641"]
       labels:
-        instance: "Synapse-Coturn"
+        instance: "{{ prom_config.instance_name }}-Coturn"
   - job_name: nginx_exporter
     static_configs:
     - targets: ["localhost:9113"]
       labels:
-        instance: "Synapse-Nginx"
+        instance: "{{ prom_config.instance_name }}-Nginx"
   - job_name: nginx_log_exporter
     static_configs:
     - targets: ["localhost:9112"]
       labels:
-        instance: "Synapse-Nginx-Logs"
+        instance: "{{ prom_config.instance_name }}-Nginx-Logs"
   - job_name: "synapse"
     scrape_interval: {{ metric_scrape_interval }}
     metrics_path: "/_synapse/metrics"
     file_sd_configs:
       - files:
-        - "{{ target_file_name }}"
+        - "{{ prom_config.file_sd_targets_file }}"

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -5,7 +5,10 @@ global:
     monitor: 'monitor'
 rule_files:
   - "/etc/prometheus/synapse-V2.rules"
-
+{% if prom_remote_write_url %}
+remote_write:
+  - url: {{ prom_remote_write_url }}
+{% endif %}
 scrape_configs:
   - job_name: pg_exporter
     static_configs:

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -35,10 +35,6 @@ scrape_configs:
   - job_name: "synapse"
     scrape_interval: {{ metric_scrape_interval }}
     metrics_path: "/_synapse/metrics"
-    static_configs:
-    - targets: ["{{ main_process_target}}"]
-      labels:
-        instance: "Synapse"
-        job: "main_process"
-        index: 1
-{{ metric_endpoint_locations }}
+    file_sd_configs:
+      - files:
+        - '/data/target.json'

--- a/conf-workers/prometheus.yml.j2
+++ b/conf-workers/prometheus.yml.j2
@@ -8,11 +8,21 @@ rule_files:
 {% if prom_config.rw_url_path %}
 remote_write:
   - url: {{ prom_config.rw_url_path }}
+    remote_timeout: {{ prom_config.rw_remote_timeout }}
+#    send_exemplars: {{ prom_config.rw_send_exemplars | string | lower }}
+    send_native_histograms: {{ prom_config.rw_send_native_histograms | string | lower }}
+#    round_robin_dns: {{ prom_config.rw_round_robin_dns | string | lower }}
     queue_config:
       max_samples_per_send: {{ prom_config.rw_max_samples_per_send}}
       capacity: {{ prom_config.rw_capacity }}
       min_shards: {{ prom_config.rw_min_shards }}
       max_shards: {{ prom_config.rw_max_shards }}
+      batch_send_deadline: {{ prom_config.rw_batch_send_deadline }}
+      min_backoff: {{ prom_config.rw_min_backoff }}
+      max_backoff: {{ prom_config.rw_max_backoff }}
+      retry_on_http_429: {{ prom_config.rw_retry_on_http_429 | string | lower }}
+#      sample_age_limit: {{ prom_config.rw_sample_age_limit }}
+
 {% endif %}
 scrape_configs:
   - job_name: pg_exporter

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -1992,10 +1992,12 @@ def generate_worker_files(
             outfile.write(prom_target_json_done)
             outfile.write("\n")
 
+        prom_remote_write_url = os.environ.get("PROMETHEUS_REMOTE_WRITE_HTTP_URL", None)
         convert(
             "/conf/prometheus.yml.j2",
             "/etc/prometheus/prometheus.yml",
             metric_scrape_interval=os.environ.get("PROMETHEUS_SCRAPE_INTERVAL", "15s"),
+            prom_remote_write_url=prom_remote_write_url,
         )
 
     # Supervisord config

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -759,6 +759,12 @@ class PromConfig:
         rw_max_samples_per_send:
         rw_min_shards:
         rw_max_shards:
+        rw_protobuf_message: This is complicated and isn't used
+        rw_remote_timeout:
+        rw_headers: Looks like this needs to be a list of key:value pairs. Isn't used
+        rw_send_exemplars:
+        rw_name: Used to label the remote write config. Isn't used(No defaults)
+        rw_send_native_histograms:
         file_sd_targets_file:
     """
     instance_name: str = "Synapse"
@@ -768,6 +774,16 @@ class PromConfig:
     rw_max_samples_per_send: str = "2000"
     rw_min_shards: str = "1"
     rw_max_shards: str = "50"
+    rw_batch_send_deadline: str = "5s"
+    rw_min_backoff: str = "30ms"
+    rw_max_backoff: str = "5s"
+    rw_retry_on_http_429: bool = False
+    rw_sample_age_limit: str = "0s"
+
+    rw_remote_timeout: str = "30s"
+    rw_send_exemplars: bool = False
+    rw_send_native_histograms: bool = False
+    rw_round_robin_dns: bool = False
     file_sd_targets_file: str = ""
 
     def __init__(self) -> None:
@@ -780,6 +796,22 @@ class PromConfig:
         )
         self.rw_min_shards = os.environ.get("PROMETHEUS_REMOTE_WRITE_MIN_SHARDS", self.rw_min_shards)
         self.rw_max_shards = os.environ.get("PROMETHEUS_REMOTE_WRITE_MAX_SHARDS", self.rw_max_shards)
+        self.rw_batch_send_deadline = os.environ.get(
+            "PROMETHEUS_REMOTE_WRITE_BATCH_SEND_DEADLINE", self.rw_batch_send_deadline
+        )
+        self.rw_min_backoff = os.environ.get("PROMETHEUS_REMOTE_WRITE_MIN_BACKOFF", self.rw_min_backoff)
+        self.rw_max_backoff = os.environ.get("PROMETHEUS_REMOTE_WRITE_MAX_BACKOFF", self.rw_max_backoff)
+        self.rw_retry_on_http_429 = os.environ.get(
+            "PROMETHEUS_REMOTE_WRITE_RETRY_ON_HTTP_429", self.rw_retry_on_http_429
+        )
+        self.rw_sample_age_limit = os.environ.get("PROMETHEUS_REMOTE_WRITE_SAMPLE_AGE_LIMIT", self.rw_sample_age_limit)
+
+        self.rw_remote_timeout = os.environ.get("PROMETHEUS_REMOTE_WRITE_REMOTE_TIMEOUT", self.rw_remote_timeout)
+        self.rw_send_exemplars = os.environ.get("PROMETHEUS_REMOTE_WRITE_SEND_EXEMPLARS", self.rw_send_exemplars)
+        self.rw_send_native_histograms = os.environ.get(
+            "PROMETHEUS_REMOTE_WRITE_SEND_NATIVE_HISTOGRAMS", self.rw_send_native_histograms
+        )
+        self.rw_round_robin_dns = os.environ.get("PROMETHEUS_REMOTE_WRITE_ROUND_ROBIN_DNS", self.rw_round_robin_dns)
 
 
 class NginxConfig:

--- a/configure_workers_and_start.py
+++ b/configure_workers_and_start.py
@@ -49,6 +49,7 @@
 # functionality should continue to work if so.
 
 import codecs
+import json
 import os
 import platform
 import re
@@ -65,8 +66,6 @@ import yaml
 from jinja2 import Environment, FileSystemLoader
 
 DEBUG = True
-if DEBUG is True:
-    import json
 
 MAIN_PROCESS_HTTP_LISTENER_PORT = 8008
 MAIN_PROCESS_HTTP_FED_LISTENER_PORT = 8448

--- a/prefix-log
+++ b/prefix-log
@@ -7,6 +7,6 @@
 #   prefix-log command [args...]
 #
 
-exec 1> >(awk '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0}' >&1)
-exec 2> >(awk '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0}' >&2)
+exec 1> >(awk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0}' >&1)
+exec 2> >(awk -W interactive '{print "'"${SUPERVISOR_PROCESS_NAME}"' | "$0}' >&2)
 exec "$@"


### PR DESCRIPTION
Better metrics support
* Now utilizes Prometheus [file based server discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config)!
  - The configuration for this is now handled automatically and produces a file at `/{$SYNAPSE_CONFIG_DIR}/prom_targets/target.json` that is pointed at by the Prometheus config for Synapse and it's workers. This file can be modified and Prometheus' file watchers should pick up those changes. However they will be overwritten on the next container rebuild/update. Safe to ignore.
  - As a side effect of this, `SYNAPSE_METRICS_ENABLE_LISTENERS` can be used to install the metric listeners on Synapse and any workers. If used instead of `SYNAPSE_ENABLE_METRICS`, Prometheus will not be started(and the other metrics capable services will not have their metrics exposed either). Safe to ignore this.
* Now you can customize your instance name for your dashboard!
  - `PROMETHEUS_INSTANCE_NAME` will default to "Synapse" and will prepend the instance name to the services you enabled that are viewable. I recommend the server name(such as example.com).


* Now supports Prometheus [remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) capabilities! [(Tuning guide)](https://prometheus.io/docs/practices/remote_write/)
  - This enables pushing Prometheus metrics outside of the container to an external TSDB. 
  - Set *PROMETHEUS_REMOTE_WRITE_HTTP_URL* to the HTTP path on your TSDB(such as [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) but there are [others](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage)). Links to docs will be in README.
  - These additional ENV variables are usable to tune remote writing:
    - `PROMETHEUS_REMOTE_WRITE_CAPACITY`
    - `PROMETHEUS_REMOTE_WRITE_MAX_SAMPLES_PER_SEND`
    - `PROMETHEUS_REMOTE_WRITE_MIN_SHARDS`
    - `PROMETHEUS_REMOTE_WRITE_MAX_SHARDS`
    - `PROMETHEUS_REMOTE_BATCH_SEND_DEADLINE`
    - `PROMETHEUS_REMOTE_WRITE_MIN_BACKOFF`
    - `PROMETHEUS_REMOTE_WRITE_MAX_BACKOFF`
    - `PROMETHEUS_REMOTE_WRITE_RETRY_ON_HTTP_429`
    - `PROMETHEUS_REMOTE_WRITE_SAMPLE_AGE_LIMIT`: disabled until supported by our prometheus version
  - These options are for adjusting other remote write parameters:
    - `PROMETHEUS_REMOTE_WRITE_REMOTE_TIMEOUT`
    - `PROMETHEUS_REMOTE_WRITE_SEND_EXEMPLARS`: disabled until exemplars can be enabled at startup
    - `PROMETHEUS_REMOTE_WRITE_SEND_NATIVE_HISTOGRAMS`
    - `PROMETHUES_REMOTE_WRITE_ROUND_ROBIN_DNS`: disabled until supported by our prometheus version
  - Will not be adding AWS and Azure authentication options(unless requested)

Additional Notes: The utility file that outputs to the docker log now will not buffer chunks of data before printing it, but will now instead output the line immediately. This may increase CPU usage slightly. The point was so that debugging lines at the start will now show startup messages from other services(including errors).