### PR TITLE
Update to trixie base, and a few other updates

### DIFF
--- a/.ci/scripts/complement.sh
+++ b/.ci/scripts/complement.sh
@@ -193,9 +193,13 @@ test_packages=(
     ./tests/msc3874
     ./tests/msc3890
     ./tests/msc3391
+    ./tests/msc3757
     ./tests/msc3930
     ./tests/msc3902
     ./tests/msc3967
+    ./tests/msc4140
+    ./tests/msc4155
+    ./tests/msc4306
 )
 # All environment variables starting with PASS_ will be shared.
 # (The prefix is stripped off before reaching the container.)

--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -19,7 +19,6 @@
 #
 
 ARG SYNAPSE_VERSION=latest
-ARG REDIS_VERSION=7.0.8
 
 ###
 ### Stage 2: Add-ons
@@ -41,7 +40,7 @@ ARG REDIS_VERSION=7.0.8
 # target image. For repeated rebuilds, this is much faster than apt installing
 # each time.
 
-FROM debian:bookworm-slim AS deps_base
+FROM debian:trixie-slim AS deps_base
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -qq && \
@@ -56,11 +55,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # based on the same debian version as the synapse image, to make sure we get
 # the expected version of libc.
 #
-# We will be using the PPA version of keydb until their docker image works for bookworm
-# FROM eqalpha/keydb:latest AS redis_base
+# A redis compatible image is needed. Previously, keydb was used. The debian based image that was used is not being
+# updated any more. Valkey is also redis compatible, and comes highly recommended
+# FROM bitnami/valkey:latest AS redis_base
 
 # Do the same for the Nginx docker image.
-FROM nginx:1.24.0 AS nginx_base
+# The first debian-based image based on trixie is for v1.29
+FROM nginx:1.29 AS nginx_base
 
 # The synapse auto compressor is from an image we build. It won't change much
 # so there's no reason to not have this pre-compiled and just borrow it. This also
@@ -105,13 +106,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # but is currently compiled against ubuntu 18.04 which doesn't work with our libssl.
 # We specifically get the keydb-tools package, as the others tend to setup service
 # entries that are not used(and cause errors).
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    echo "deb https://download.keydb.dev/open-source-dist bookworm main" | tee /etc/apt/sources.list.d/keydb.list && \
-    wget -O /etc/apt/trusted.gpg.d/keydb.gpg https://download.keydb.dev/open-source-dist/keyring.gpg && \
-    apt-get update -qq && apt-get install -yqq \
-        keydb-tools \
-    && rm -rf /var/lib/apt/lists/*
+# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+#    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+#    echo "deb https://download.keydb.dev/open-source-dist bookworm main" | tee /etc/apt/sources.list.d/keydb.list && \
+#    wget -O /etc/apt/trusted.gpg.d/keydb.gpg https://download.keydb.dev/open-source-dist/keyring.gpg && \
+#    apt-get update -qq && apt-get install -yqq \
+#        keydb-tools \
+#    && rm -rf /var/lib/apt/lists/*
 
 # Prepare directories. Do it in one layer
 RUN mkdir -p /etc/supervisor/conf.d && \
@@ -124,8 +125,8 @@ RUN mkdir -p /etc/supervisor/conf.d && \
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install supervisor~=4.2
 
-# Copy over redis and nginx
-# COPY --from=redis_base /usr/local/bin/keydb-server /usr/local/bin
+# Copy over valkey and nginx
+# COPY --from=redis_base /usr/local/bin/valkey-server /usr/local/bin
 
 COPY --from=nginx_base /usr/sbin/nginx /usr/sbin
 COPY --from=nginx_base /usr/share/nginx /usr/share/nginx
@@ -134,7 +135,7 @@ COPY --from=nginx_base /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-l
 COPY --from=nginx_base /etc/nginx /etc/nginx
 RUN rm /etc/nginx/conf.d/default.conf
 
-# Copy over Prometheus. Should we bring the website files. It's 10's of MB's
+# Copy over Prometheus. Should we bring the website files? It's 10's of MB's
 COPY --from=deps_base /usr/bin/prometheus /usr/bin
 COPY --from=deps_base /usr/share/prometheus/* /usr/share/prometheus
 # And Synapse's Prometheus rule file

--- a/Dockerfile-unified
+++ b/Dockerfile-unified
@@ -57,7 +57,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #
 # A redis compatible image is needed. Previously, keydb was used. The debian based image that was used is not being
 # updated any more. Valkey is also redis compatible, and comes highly recommended
-# FROM bitnami/valkey:latest AS redis_base
+FROM bitnami/valkey:latest AS redis_base
 
 # Do the same for the Nginx docker image.
 # The first debian-based image based on trixie is for v1.29
@@ -87,7 +87,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libevent-extra-2.1-7 \
       libevent-openssl-2.1-7 \
       libevent-pthreads-2.1-7 \
-      libhiredis0.14 \
+      libhiredis1.1.0 \
       libjemalloc2 \
       libjpeg62-turbo \
       libmicrohttpd12 \
@@ -102,18 +102,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       xmlsec1 \
       && rm -rf /var/lib/apt/lists/*
 
-# Install keydb from their supplied PPA. Preferably, the docker image would be better,
-# but is currently compiled against ubuntu 18.04 which doesn't work with our libssl.
-# We specifically get the keydb-tools package, as the others tend to setup service
-# entries that are not used(and cause errors).
-# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-#    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-#    echo "deb https://download.keydb.dev/open-source-dist bookworm main" | tee /etc/apt/sources.list.d/keydb.list && \
-#    wget -O /etc/apt/trusted.gpg.d/keydb.gpg https://download.keydb.dev/open-source-dist/keyring.gpg && \
-#    apt-get update -qq && apt-get install -yqq \
-#        keydb-tools \
-#    && rm -rf /var/lib/apt/lists/*
-
 # Prepare directories. Do it in one layer
 RUN mkdir -p /etc/supervisor/conf.d && \
     mkdir /var/log/nginx /var/cache/nginx && \
@@ -126,20 +114,18 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install supervisor~=4.2
 
 # Copy over valkey and nginx
-# COPY --from=redis_base /usr/local/bin/valkey-server /usr/local/bin
+COPY --from=redis_base /opt/bitnami/valkey/* /opt/bitnami/valkey/
 
 COPY --from=nginx_base /usr/sbin/nginx /usr/sbin
 COPY --from=nginx_base /usr/share/nginx /usr/share/nginx
 COPY --from=nginx_base /usr/lib/nginx /usr/lib/nginx
-COPY --from=nginx_base /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/
+# COPY --from=nginx_base /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=nginx_base /etc/nginx /etc/nginx
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy over Prometheus. Should we bring the website files? It's 10's of MB's
 COPY --from=deps_base /usr/bin/prometheus /usr/bin
-COPY --from=deps_base /usr/share/prometheus/* /usr/share/prometheus
-# And Synapse's Prometheus rule file
-COPY /contrib/prometheus/synapse-V2.rules /etc/prometheus
+COPY --from=deps_base /usr/share/prometheus/* /usr/share/prometheus/
 COPY /contrib/mtail/ /conf/mtail/
 
 COPY --from=tools /out /

--- a/complement/Dockerfile
+++ b/complement/Dockerfile
@@ -19,8 +19,8 @@ FROM $FROM
 # the same debian version as Synapse's docker image (so the versions of the
 # shared libraries match).
 RUN adduser --system --uid 999 postgres --home /var/lib/postgresql
-COPY --from=postgres:16-bookworm /usr/lib/postgresql /usr/lib/postgresql
-COPY --from=postgres:16-bookworm /usr/share/postgresql /usr/share/postgresql
+COPY --from=postgres:16-trixie /usr/lib/postgresql /usr/lib/postgresql
+COPY --from=postgres:16-trixie /usr/share/postgresql /usr/share/postgresql
 RUN mkdir /var/run/postgresql && chown postgres /var/run/postgresql
 ENV PATH="${PATH}:/usr/lib/postgresql/16/bin"
 ENV PGDATA=/var/lib/postgresql/data

--- a/complement/Dockerfile
+++ b/complement/Dockerfile
@@ -21,6 +21,7 @@ FROM $FROM
 RUN adduser --system --uid 999 postgres --home /var/lib/postgresql
 COPY --from=postgres:16-trixie /usr/lib/postgresql /usr/lib/postgresql
 COPY --from=postgres:16-trixie /usr/share/postgresql /usr/share/postgresql
+COPY --from=postgres:16-trixie /usr/lib/x86_64-linux-gnu/libicu*.so.* /usr/lib/x86_64-linux-gnu/
 RUN mkdir /var/run/postgresql && chown postgres /var/run/postgresql
 ENV PATH="${PATH}:/usr/lib/postgresql/16/bin"
 ENV PGDATA=/var/lib/postgresql/data

--- a/complement/conf/workers-shared-extra.yaml.j2
+++ b/complement/conf/workers-shared-extra.yaml.j2
@@ -7,6 +7,7 @@
 #}
 
 ## Server ##
+public_baseurl: http://127.0.0.1:8008/
 report_stats: False
 trusted_key_servers: []
 enable_registration: true
@@ -43,10 +44,6 @@ rc_message:
   burst_count: 9999
 
 rc_registration:
-  per_second: 9999
-  burst_count: 9999
-
-rc_registration_token_validity:
   per_second: 9999
   burst_count: 9999
 
@@ -88,6 +85,22 @@ rc_invites:
   per_user:
     per_second: 1000
     burst_count: 1000
+  per_issuer:
+    per_second: 1000
+    burst_count: 1000
+
+rc_presence:
+  per_user:
+    per_second: 9999
+    burst_count: 9999
+
+rc_delayed_event_mgmt:
+  per_second: 9999
+  burst_count: 9999
+
+rc_room_creation:
+  per_second: 9999
+  burst_count: 9999
 
 federation_rr_transactions_per_room_per_second: 9999
 
@@ -108,6 +121,20 @@ experimental_features:
   msc3967_enabled: true
   # Expose a room summary for public rooms
   msc3266_enabled: true
+  # Send to-device messages to application services
+  msc2409_to_device_messages_enabled: true
+  # Allow application services to masquerade devices
+  msc3202_device_masquerading: true
+  # Sending device list changes, one-time key counts and fallback key usage to application services
+  msc3202_transaction_extensions: true
+  # Proxy OTK claim requests to exclusive ASes
+  msc3983_appservice_otk_claims: true
+  # Proxy key queries to exclusive ASes
+  msc3984_appservice_key_query: true
+  # Invite filtering
+  msc4155_enabled: true
+  # Thread Subscriptions
+  msc4306_enabled: true
 
 server_notices:
   system_mxid_localpart: _server
@@ -115,10 +142,18 @@ server_notices:
   system_mxid_avatar_url: ""
   room_name: "Server Alert"
 
+# Enable delayed events (msc4140)
+max_event_delay_duration: 24h
+
 
 # Disable sync cache so that initial `/sync` requests are up-to-date.
 caches:
   sync_response_cache_duration: 0
+
+
+# Complement assumes that it can publish to the room list by default.
+room_list_publication_rules:
+  - action: allow
 
 
 {% include "shared-orig.yaml.j2" %}

--- a/conf-workers/supervisord.conf.j2
+++ b/conf-workers/supervisord.conf.j2
@@ -18,8 +18,8 @@ stderr_logfile_maxbytes=0
 username=www-data
 autorestart=true
 
-[program:keydb]
-command=/usr/local/bin/prefix-log /usr/bin/keydb-server --unixsocket /dev/shm/redis.sock --server-threads 8
+[program:valkey]
+command=/usr/local/bin/prefix-log /opt/bitnami/valkey/valkey-server --unixsocket /dev/shm/redis.sock --io-threads 2
 priority=1
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
The docker image was based on debian-bookworm. Well that is starting to lose support, and the base Synapse image has already been moved to trixie. There will have to be a few other changes to support this migration:
* redis/keydb -> valkey
* nginx 1.24 -> nginx 1.29
* synapse-tools -> bookworm:trixie, golang1.22:golang1.25

Went ahead and brought Complement testing up to current. This probably isn't needed, as comprehensive endpoint testing isn't something I'm concerned about. Only that nothing got broken

Fixes:
* #22 